### PR TITLE
[HLAB-3] Implement Alertmanager

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 Application to monitor the metrics of the HomeLab infrastructure using Prometheus and Grafana.
 
 Application is being deployed by [`Homelab-IaC`](https://github.com/yureutaejin/homelab-iac)
+
+## Quick Start
+
+1. Set configuration for each of components(`prometheus`, `grafana`, etc...)
+   - `alertmanager` needs SLACK_WEBHOOK_URL which can not be directly set in `alertmanager.yml` file. You need to set `sed -i` command or `envsubst` command in your CD workflows separately.
+2. Run `docker compose up -d` in the root directory of the repository

--- a/alertmanager/alertmanager.yml
+++ b/alertmanager/alertmanager.yml
@@ -1,5 +1,5 @@
 global:
-  resolve_timeout: 5m
+  resolve_timeout: 2m
 
 route:
   receiver: "slack-alerts"
@@ -14,5 +14,23 @@ receivers:
       - api_url: ${SLACK_WEBHOOK_URL}
         channel: ${SLACK_CHANNEL}
         send_resolved: true
-        title: "{{ .CommonAnnotations.summary }}"
-        text: "{{ .CommonAnnotations.description }}"
+        title: >-
+          {{ if eq .Status "firing" }}
+            🚨 Alert: Machine Health Alerts - {{ .CommonLabels.instance }}
+          {{ else }}
+            ✅ Resolved: Machine Health Alerts - {{ .CommonLabels.instance }}
+          {{ end }}
+        text: >-
+          {{ if eq .Status "firing" }}
+            Alert Details:
+            - Instance: {{ .CommonLabels.instance }}
+            - Job: {{ .CommonLabels.job }}
+            - Severity: {{ .CommonLabels.severity }}
+            - Description: {{ .CommonAnnotations.description }}
+          {{ else }}
+            Resolved Details:
+            - Instance: {{ .CommonLabels.instance }}
+            - Job: {{ .CommonLabels.job }}
+            - Severity: {{ .CommonLabels.severity }}
+            - The `Machine down` issue has been resolved at {{ .CommonLabels.instance }}.
+          {{ end }}

--- a/alertmanager/alertmanager.yml
+++ b/alertmanager/alertmanager.yml
@@ -1,0 +1,18 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: "slack-alerts"
+  group_by: ["alertname", "instance"]
+  group_wait: 30s
+  group_interval: 1m
+  repeat_interval: 12h
+
+receivers:
+  - name: "slack-alerts"
+    slack_configs:
+      - api_url: ${SLACK_WEBHOOK_URL}
+        channel: ${SLACK_CHANNEL}
+        send_resolved: true
+        title: "{{ .CommonAnnotations.summary }}"
+        text: "{{ .CommonAnnotations.description }}"

--- a/alertmanager/compose.yaml
+++ b/alertmanager/compose.yaml
@@ -1,0 +1,9 @@
+services:
+  alertmanager:
+    image: prom/alertmanager:latest
+    container_name: alertmanager
+    restart: always
+    volumes:
+      - ./:/etc/alertmanager:ro
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,6 +7,15 @@ services:
       - 9090:9090
     networks: 
       - prometheus-grafana
+
+  alertmanager:
+    extends:
+      file: ./alertmanager/compose.yaml
+      service: alertmanager
+    ports:
+      - 9093:9093
+    networks:
+      - prometheus-grafana
   
   grafana:
     extends:

--- a/exporter/compose.yaml
+++ b/exporter/compose.yaml
@@ -7,6 +7,6 @@ services:
       - '--web.listen-address=:9988'
     network_mode: host
     pid: host
-    restart: unless-stopped
+    restart: always
     volumes:
       - '/:/host:ro,rslave'

--- a/exporter/gpu-node-override.yaml
+++ b/exporter/gpu-node-override.yaml
@@ -7,7 +7,7 @@ services:
       - NVIDIA_VISIBLE_DEVICES=all
     network_mode: host
     pid: host
-    restart: unless-stopped
+    restart: always
     cap_add:
       - SYS_ADMIN
     ports:

--- a/grafana/compose.yaml
+++ b/grafana/compose.yaml
@@ -2,7 +2,7 @@
   grafana:
     image: grafana/grafana:latest
     container_name: grafana
-    restart: unless-stopped
+    restart: always
     volumes:
       - ./grafana.ini:/etc/grafana/grafana.ini
       - ./provisioning:/etc/grafana/provisioning

--- a/prometheus/alert_rules.yml
+++ b/prometheus/alert_rules.yml
@@ -1,11 +1,12 @@
 groups:
-  - name: TargetHealthAlerts
+  - name: TargetMachineHealth
     rules:
-      - alert: TargetDown
+      - alert: TargetMachineDown
         expr: up{job="node-exporter"} == 0
         for: 1m
         labels:
           severity: critical
+          layer: machine
         annotations:
           summary: "Machine Down Alert: {{ $labels.job }} at {{ $labels.instance }}"
           description: "The target {{ $labels.instance }} of job {{ $labels.job }} has been down for more than 1 minute."

--- a/prometheus/alert_rules.yml
+++ b/prometheus/alert_rules.yml
@@ -2,7 +2,7 @@ groups:
   - name: TargetHealthAlerts
     rules:
       - alert: TargetDown
-        expr: up ==0
+        expr: up{job="node-exporter"} == 0
         for: 1m
         labels:
           severity: critical

--- a/prometheus/alert_rules.yml
+++ b/prometheus/alert_rules.yml
@@ -1,0 +1,11 @@
+groups:
+  - name: TargetHealthAlerts
+    rules:
+      - alert: TargetDown
+        expr: up ==0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Machine Down Alert: {{ $labels.job }} at {{ $labels.instance }}"
+          description: "The target {{ $labels.instance }} of job {{ $labels.job }} has been down for more than 1 minute."

--- a/prometheus/compose.yaml
+++ b/prometheus/compose.yaml
@@ -2,7 +2,7 @@ services:
   prometheus:
     image: prom/prometheus:latest
     container_name: prometheus
-    restart: unless-stopped
+    restart: always
     volumes:
       - ./:/etc/prometheus:ro
       - prometheus-data:/prometheus/data

--- a/prometheus/compose.yaml
+++ b/prometheus/compose.yaml
@@ -4,7 +4,7 @@ services:
     container_name: prometheus
     restart: unless-stopped
     volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./:/etc/prometheus:ro
       - prometheus-data:/prometheus/data
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -7,6 +7,6 @@ scrape_configs:
     scrape_interval: 3s
     static_configs:
       - targets: # need to isolate `targets` value so that it can be inserted from another file or variable.
-          - yureutae-server-1:9988
-          - yureutae-server-2:9988
-          - yureutae-server-3:9988
+          - yureutae-server-1.tail5c961c.ts.net:9988
+          - yureutae-server-2.tail5c961c.ts.net:9988
+          - yureutae-server-3.tail5c961c.ts.net:9988

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -10,3 +10,6 @@ scrape_configs:
           - yureutae-server-1.tail5c961c.ts.net:9988
           - yureutae-server-2.tail5c961c.ts.net:9988
           - yureutae-server-3.tail5c961c.ts.net:9988
+
+rule_files:
+  - "./alert_rules.yml"

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -13,3 +13,9 @@ scrape_configs:
 
 rule_files:
   - "./alert_rules.yml"
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - yureutae-server-1.tail5c961c.ts.net:9093


### PR DESCRIPTION
## Description

### What

Now can check machine's status with Slack Message
- Add alert rule and Alertmanager
- Add Slack Notification feature using `Slack API's WebHook`

### Why

- To detect which server has been downed immediately and restore it.

### How

- Set alert rule for node exporter
- Add Alertmanager so that prometheus could push alert according to alert rule and send.
- Using Slack API's WebHook, Alertmanager can push message if machine's status is unstable or issues are resolved

### Weakness

- Need to add sub shell-script for Alertmanager's static config file.
   - `sed -i`
   - or `envsubst`

